### PR TITLE
coronawiki.org unter Dashboard hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Stand: 19.03.2020 - 16:30Uhr
     Karte](https://interaktiv.morgenpost.de/corona-virus-karte-infektionen-deutschland-weltweit/)
   - [Dashboard zur Entwicklung](https://avatorl.org/covid-19/)
   - [European Center for Disease Control](https://qap.ecdc.europa.eu/public/extensions/COVID-19/COVID-19.html)
+  - [Coronavirus statistics and information](https://coronawiki.org/)
 
 
 ## Lageinformationen


### PR DESCRIPTION
Kürzlich auf Twitter von Sascha Pallenberg geteilt. Eventuell passt das mit in die Sammlung.